### PR TITLE
{DOL, REL}ProgramBuilder: Prevent potential null pointer dereferences in load()

### DIFF
--- a/src/main/java/gamecubeloader/dol/DOLProgramBuilder.java
+++ b/src/main/java/gamecubeloader/dol/DOLProgramBuilder.java
@@ -92,7 +92,7 @@ public final class DOLProgramBuilder {
 					32, dol.bssMemoryAddress);
 		}
 		
-		if (mapLoadedResult.loaded == false) {
+		if (mapLoadedResult != null && mapLoadedResult.loaded == false) {
 			if (OptionDialog.showOptionNoCancelDialog(null, "Load Symbols?", "Would you like to load a symbol map for this DOL executable?", "Yes", "No", null) == 1) {
 				var fileChooser = new GhidraFileChooser(null);
 				fileChooser.setCurrentDirectory(provider.getFile().getParentFile());

--- a/src/main/java/gamecubeloader/rel/RELProgramBuilder.java
+++ b/src/main/java/gamecubeloader/rel/RELProgramBuilder.java
@@ -282,9 +282,8 @@ public class RELProgramBuilder  {
 					this.symbolInfoList.add(mapLoadedResult.symbolMap);
 				}
 			}
-			
-			
-			if (mapLoadedResult.loaded == false) {
+
+			if (mapLoadedResult != null && mapLoadedResult.loaded == false) {
 				// Ask if the user wants to load a symbol map file.
 				if (OptionDialog.showOptionNoCancelDialog(null, "Load Symbols?", String.format("Would you like to load a symbol map for the relocatable module %s?", relInfo.name),
 						"Yes", "No", null) == 1) {


### PR DESCRIPTION
mapLoadedResult is initially set to null and only assigned to if automatic map loading is enabled. If this option is ever disabled, then a null pointer dereference will occur.

To alleviate this, we check against null before accessing mapLoadedResult's member variables.