### PR TITLE
RELProrgramBuilder: Remove fallthrough in R_PPC_ADDR16_HI case in Relocate()

### DIFF
--- a/src/main/java/gamecubeloader/rel/RELProgramBuilder.java
+++ b/src/main/java/gamecubeloader/rel/RELProgramBuilder.java
@@ -417,24 +417,20 @@ public class RELProgramBuilder  {
 				case RELProgramBuilder.R_PPC_ADDR32:
 					programMemory.setInt(targetAddress, (int)(importSectionAddress + relocation.addend), true);
 					break;
-					
+
+				case RELProgramBuilder.R_PPC_ADDR16:
 				case RELProgramBuilder.R_PPC_ADDR16_LO:
 					writeValue = (importSectionAddress + relocation.addend) & 0xFFFF;
-					
+
 					programMemory.setShort(targetAddress, (short)writeValue, true);
 					break;
-					
+
 				case RELProgramBuilder.R_PPC_ADDR16_HI:
 					writeValue = ((importSectionAddress + relocation.addend) >> 16) & 0xFFFF;
 					
 					programMemory.setShort(targetAddress, (short)writeValue, true);
-					
-				case RELProgramBuilder.R_PPC_ADDR16:
-					writeValue = (importSectionAddress + relocation.addend) & 0xFFFF;
-					
-					programMemory.setShort(targetAddress, (short)writeValue, true);
 					break;
-					
+
 				case RELProgramBuilder.R_DOLPHIN_NOP:
 				case RELProgramBuilder.R_PPC_NONE:
 					break;


### PR DESCRIPTION
Avoids erroneously steamrolling set values in memory. While we're at it, we can also join the duplicate code in `R_PPC_ADDR16` and `R_PPC_ADDR16_LO`.