### PR TITLE
Don't take the basename of a REL's name when asking for a base memory address

### DIFF
--- a/src/main/java/gamecubeloader/rel/RELProgramBuilder.java
+++ b/src/main/java/gamecubeloader/rel/RELProgramBuilder.java
@@ -211,7 +211,7 @@ public class RELProgramBuilder  {
 			    var setValidAddress = false;
 			    while (!setValidAddress) {
     			    var selectedAddress = OptionDialog.showInputSingleLineDialog(null, "Specify Memory Address", "Specify the base memory address for Module " +
-    			            FilenameUtils.getBaseName(relInfo.name), Long.toHexString(relBaseAddress));
+    			            relInfo.name, Long.toHexString(relBaseAddress));
     			    
     			    if (selectedAddress == null) {
     			        break; // The user selected the cancel dialog.


### PR DESCRIPTION
Super Monkey Ball 2 names all of its RELs as `mkb2.some_name.rel`. When asking the user to specify a base memory address for a module, the basename of `mkb2.some_name` is taken leaving a less-than-helpful `mkb2`. This PR simply removes the `FilenameUtils.getBaseName`.

Before:
![image](https://user-images.githubusercontent.com/5341220/67035926-871c6080-f112-11e9-8138-f9ed9ec133ca.png)

After:
![image](https://user-images.githubusercontent.com/5341220/67035961-98656d00-f112-11e9-890d-df39f4eeaab4.png)

