### PR TITLE
Fix analyzer not appearing when analyzing memory dumps

### DIFF
--- a/src/main/java/gamecubeloader/analyzer/GCAnalyzer.java
+++ b/src/main/java/gamecubeloader/analyzer/GCAnalyzer.java
@@ -46,11 +46,19 @@ public class GCAnalyzer extends AbstractAnalyzer {
 
     @Override
     public boolean getDefaultEnablement(Program program) {
-        return true;
+        if (program.getLanguageID().getIdAsString().equals("PowerPC:BE:32:Gekko_Broadway") &&
+                program.getExecutableFormat().equals(GameCubeLoader.BIN_NAME)) {
+            return true;
+        }
+
+        return false;
     }
     
     @Override
     public boolean canAnalyze(Program program) {
+        if (program.getLanguageID().getIdAsString().equals("PowerPC:BE:32:Gekko_Broadway")) {
+            return true;
+        }
         return program.getExecutableFormat().equals(GameCubeLoader.BIN_NAME);
     }
     


### PR DESCRIPTION
The fix is very simple. 

if the assembly language used for the program is the Gamecube/Wii custom one. we enable the analyzer. Also, the analyzer is only enabled by default if the assembly language is the correct *and* the executable format is "Nintendo GameCube Binary".

Step toward #8 