### PR TITLE
Special case DOL entry point for sysmenu.

### DIFF
--- a/src/main/java/gamecubeloader/dol/DOLHeader.java
+++ b/src/main/java/gamecubeloader/dol/DOLHeader.java
@@ -165,7 +165,7 @@ public class DOLHeader {
 			return false;
 		}
 		
-		if (this.entryPoint < 0x80000000L || this.entryPoint > 0x817FFFFFL) {
+		if ((this.entryPoint < 0x80000000L || this.entryPoint > 0x817FFFFFL) && this.entryPoint != 0x00003400) {
 			return false;
 		}
 		


### PR DESCRIPTION
Add a special case to allow for loading the Wii's System Menu binaries which have an entry point at 0x00003400.