### PR TITLE
Fix >8 float arguments

### DIFF
--- a/data/languages/ppc_gekko_broadway.cspec
+++ b/data/languages/ppc_gekko_broadway.cspec
@@ -8,44 +8,29 @@
   <default_proto>
     <prototype name="__stdcall" extrapop="0" stackshift="0">
       <input pointermax="8">
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f1"/>
         </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f2"/>
         </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f3"/>
         </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f4"/>
         </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f5"/>
         </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f6"/>
         </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f7"/>
         </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+        <pentry minsize="4" maxsize="8" metatype="float" extension="float">
           <register name="f8"/>
-        </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
-          <register name="f9"/>
-        </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
-          <register name="f10"/>
-        </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
-          <register name="f11"/>
-        </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
-          <register name="f12"/>
-        </pentry>
-        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
-          <register name="f13"/>
         </pentry>
         <pentry minsize="1" maxsize="4">
           <register name="r3"/>


### PR DESCRIPTION
Since the language spec now lives here, this is a duplicate of https://github.com/aldelaro5/ghidra-gekko-broadway-lang/pull/4.

Original PR description:
> Discovered by @Antidote. Float arguments above f8 should go to the stack. minsize upped to 4 (though it doesn't appear to change anything)

