### PR TITLE
Fix and improve Symbol Export to be Dolphin-readable

### DIFF
--- a/src/main/java/gamecubeloader/plugins/SymbolMapExporterPluginPackage.java
+++ b/src/main/java/gamecubeloader/plugins/SymbolMapExporterPluginPackage.java
@@ -22,10 +22,10 @@ import resources.ResourceManager;
  * Plugin package for the Symbol Map Exporter plugin.
  */
 public class SymbolMapExporterPluginPackage extends PluginPackage {
-    public static final String NAME = "Symbol Map Exporter";
+    public static final String NAME = "Symbol Map Exporter for Dolphin Emulator";
 
     public SymbolMapExporterPluginPackage() {
         super(NAME, ResourceManager.loadImage("images/vcard.png"),
-                "For exporting symbols to map files");
+                "For exporting symbols to map files for Dolphin Emulator");
     }
 }


### PR DESCRIPTION
It seems the format Dolphin reads is slightly different what the
previous Symbol Export outputted, requiring those section headers.
Additionally, they are split by function and data symbols, so also do it
here.

For convenience, the plugin tries to search the Maps folder of an
Dolphin Emulator user data folder, so it can be quickly loaded into
Dolphin for quick debugging or something.
Also, it remembers the path for an session.