### PR TITLE
More detailed semantic description of psq_l/st

### DIFF
--- a/data/languages/ppc_gekko_broadway.slaspec
+++ b/data/languages/ppc_gekko_broadway.slaspec
@@ -130,12 +130,13 @@ define register offset=0x4000 size=8 [
 	f0  f1  f2  f3  f4  f5  f6  f7  f8  f9  f10 f11 f12 f13 f14 f15
 	f16 f17 f18 f19 f20 f21 f22 f23 f24 f25 f26 f27 f28 f29 f30 f31 ];
 
-# Paired singles registers
-define register offset=0x4000 size=4 [
-	 ps0_0  ps0_1  ps1_0  ps1_1  ps2_0  ps2_1  ps3_0  ps3_1  ps4_0  ps4_1  ps5_0  ps5_1  ps6_0  ps6_1  ps7_0  ps7_1
-	 ps8_0  ps8_1  ps9_0  ps9_1 ps10_0 ps10_1 ps11_0 ps11_1 ps12_0 ps12_1 ps13_0 ps13_1 ps14_0 ps14_1 ps15_0 ps15_1
-	ps16_0 ps16_1 ps17_0 ps17_1 ps18_0 ps18_1 ps19_0 ps19_1 ps20_0 ps20_1 ps21_0 ps21_1 ps22_0 ps22_1 ps23_0 ps23_1
-	ps24_0 ps24_1 ps25_0 ps25_1 ps26_0 ps26_1 ps27_0 ps27_1 ps28_0 ps28_1 ps29_0 ps29_1 ps30_0 ps30_1 ps31_0 ps31_1 ];
+# ps1 registers
+# Note: in gekko and broadway those are actually 32-bit, but use the same size as ps0 for definition convenience and noisy casts in decompilation.
+define register offset=0x5000 size=8 [
+         ps0_1 ps1_1  ps2_1  ps3_1  ps4_1  ps5_1  ps6_1  ps7_1
+         ps8_1 ps9_1  ps10_1 ps11_1 ps12_1 ps13_1 ps14_1 ps15_1
+        ps16_1 ps17_1 ps18_1 ps19_1 ps20_1 ps21_1 ps22_1 ps23_1
+        ps24_1 ps25_1 ps26_1 ps27_1 ps28_1 ps29_1 ps30_1 ps31_1];
 
 # Define context bits
 define register offset=0x6000 size=4   contextreg;
@@ -392,6 +393,9 @@ define token instr(32)
 	ps0S=(21,25)
 	ps1S=(21,25)
 	fT=(21,25)
+
+	# Hack to set ps1 in single fp instruction
+	ps1T=(21,25)
   I=(12,14)
   IX=(7,9)
 	IMM=(11,15)
@@ -577,12 +581,12 @@ attach variables [ fD fB fA fC fS fT ]
 
 # Paired singles (individual components)
 attach variables [ ps0D ps0B ps0A ps0C ps0S ]
-                 [  ps0_0  ps1_0  ps2_0  ps3_0  ps4_0  ps5_0  ps6_0  ps7_0
-                    ps8_0  ps9_0 ps10_0 ps11_0 ps12_0 ps13_0 ps14_0 ps15_0
-                   ps16_0 ps17_0 ps18_0 ps19_0 ps20_0 ps21_0 ps22_0 ps23_0
-                   ps24_0 ps25_0 ps26_0 ps27_0 ps28_0 ps29_0 ps30_0 ps31_0 ];
+                 [ f0  f1  f2  f3  f4  f5  f6  f7
+                   f8  f9  f10 f11 f12 f13 f14 f15
+                   f16 f17 f18 f19 f20 f21 f22 f23
+                   f24 f25 f26 f27 f28 f29 f30 f31 ];
 
-attach variables [ ps1D ps1B ps1A ps1C ps1S ]
+attach variables [ ps1D ps1B ps1A ps1C ps1S ps1T ]
                  [  ps0_1  ps1_1  ps2_1  ps3_1  ps4_1  ps5_1  ps6_1  ps7_1
                     ps8_1  ps9_1 ps10_1 ps11_1 ps12_1 ps13_1 ps14_1 ps15_1
                    ps16_1 ps17_1 ps18_1 ps19_1 ps20_1 ps21_1 ps22_1 ps23_1
@@ -1163,7 +1167,7 @@ macro load_ps(ps0D, ps1D, EA, W, I) {
 	ls[0,3] = I[24,6];
 	wFlag = W;
 	one:1 = 1;
-	floatOne:4 = int2float(one);
+	floatOne:8 = int2float(one);
 
 	local scale;
 	if (ls == 0) goto <noscale>;
@@ -1201,9 +1205,9 @@ macro load_ps(ps0D, ps1D, EA, W, I) {
 	goto inst_next;
 
 	<float>
-	ps0D = *:4(EA);
+	ps0D = float2float(*:4(EA));
 	if (wFlag) goto <floatw1>;
-	ps1D = *:4(EA + 4);
+	ps1D = float2float(*:4(EA + 4));
 	goto inst_next;
 	<floatw1>
 	ps1D = floatOne;
@@ -1248,7 +1252,7 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 	goto <continue_scale>;
 	<noscale>
 	one:1 = 1;
-	floatOne:4 = int2float(one);
+	floatOne:8 = int2float(one);
 	scale = floatOne;
 
 	<continue_scale>
@@ -1270,9 +1274,9 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 	goto inst_next;
 
 	<float>
-	*:4(EA) = ps0S;
+	*:4(EA) = float2float(ps0S);
 	if (wFlag == 1) goto inst_next;
-	*:4(EA + 4) = ps1S;
+	*:4(EA + 4) = float2float(ps1S);
 }
 
 :psq_st fS,dPlusRaOrZeroAddressPS,W,I is OP=60 & fS & A & W & I & dPlusRaOrZeroAddressPS & ps0S & ps1S
@@ -1386,75 +1390,75 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 
 :ps_madd fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=29 & Rc=0 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	ps0D = tmp1 f+ ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps0C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	ps1D = tmp2 f+ ps1B;
 }
 
 :ps_madd. fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=29 & Rc=1 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	ps0D = tmp1 f+ ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps0C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	ps1D = tmp2 f+ ps1B;
 	cr1flags();
 }
 
 :ps_madds0 fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=14 & Rc=0 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	ps0D = tmp1 f+ ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps0C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps0C;
+	tmp2:8 = ps1A f* ps0C;
 	ps1D = tmp2 f+ ps1B;
 }
 
 :ps_madds0. fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=14 & Rc=1 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	ps0D = tmp1 f+ ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps0C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps0C;
+	tmp2:8 = ps1A f* ps0C;
 	ps1D = tmp2 f+ ps1B;
 	cr1flags();
 }
 
 :ps_madds1 fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=15 & Rc=0 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps1C;
+	tmp1:8 = ps0A f* ps1C;
 	ps0D = tmp1 f+ ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps1C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	ps1D = tmp2 f+ ps1B;
 }
 
 :ps_madds1. fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=15 & Rc=1 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps1C;
+	tmp1:8 = ps0A f* ps1C;
 	ps0D = tmp1 f+ ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps1C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	ps1D = tmp2 f+ ps1B;
 	cr1flags();
 }
@@ -1526,25 +1530,25 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 
 :ps_msub fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=28 & Rc=0 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	ps0D = tmp1 f- ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(fA) | nan(fC) | nan(fB);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	ps1D = tmp2 f- ps1B;
 }
 
 :ps_msub. fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=28 & Rc=1 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	ps0D = tmp1 f- ps0B;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(fA) | nan(fC) | nan(fB);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	ps1D = tmp2 f- ps1B;
 	cr1flags();
 }
@@ -1622,28 +1626,28 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 
 :ps_nmadd fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=31 & Rc=0 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	tmp1 = tmp1 f+ ps0B;
 	ps0D = f- tmp1;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps0C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	tmp2 = tmp2 f+ ps1B;
 	ps1D = f- tmp2;
 }
 
 :ps_nmadd. fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=31 & Rc=1 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	tmp1 = tmp1 f+ ps0B;
 	ps0D = f- tmp1;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0A) | nan(ps0C) | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	tmp2 = tmp2 f+ ps1B;
 	ps1D = f- tmp2;
 	cr1flags();
@@ -1651,28 +1655,28 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 
 :ps_nmsub fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=30 & Rc=0 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	tmp1 = tmp1 f- ps0B;
 	ps0D = f- tmp1;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(fA) | nan(fC) | nan(fB);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	tmp2 = tmp2 f- ps1B;
 	ps1D = f- tmp2;
 }
 
 :ps_nmsub. fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=30 & Rc=1 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	tmp1:4 = ps0A f* ps0C;
+	tmp1:8 = ps0A f* ps0C;
 	tmp1 = tmp1 f- ps0B;
 	ps0D = f- tmp1;
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(fA) | nan(fC) | nan(fB);
 	setSummaryFPSCR();
-	tmp2:4 = ps1A f* ps1C;
+	tmp2:8 = ps1A f* ps1C;
 	tmp2 = tmp2 f- ps1B;
 	ps1D = f- tmp2;
 	cr1flags();
@@ -1680,66 +1684,66 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 
 :ps_res fD,fB is OP=4 & fD & BITS_16_20=0 & fB & BITS_6_10=0 & XOP_1_5=24 & Rc=0 & ps0D & ps1D & ps0B & ps1B
 {
-	one:4 = 1;
-	floatOne:4 = int2float(one);
-	tmp1:4 = float2float(floatOne f/ ps0B);
+	one:8 = 1;
+	floatOne:8 = int2float(one);
+	tmp1:8 = float2float(floatOne f/ ps0B);
 	ps0D = float2float(tmp1);
 	setFPRF(fD);
 	fp_zx = fp_zx | (fB f== 0);
 	fp_vxsnan = fp_vxsnan | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = float2float(floatOne f/ ps1B);
+	tmp2:8 = float2float(floatOne f/ ps1B);
 	ps1D = float2float(tmp2);
 }
 
 :ps_res. fD,fB is OP=4 & fD & BITS_16_20=0 & fB & BITS_6_10=0 & XOP_1_5=24 & Rc=1 & ps0D & ps1D & ps0B & ps1B
 {
-	one:4 = 1;
-	floatOne:4 = int2float(one);
-	tmp1:4 = float2float(floatOne f/ ps0B);
+	one:8 = 1;
+	floatOne:8 = int2float(one);
+	tmp1:8 = float2float(floatOne f/ ps0B);
 	ps0D = float2float(tmp1);
 	setFPRF(fD);
 	fp_zx = fp_zx | (fB f== 0);
 	fp_vxsnan = fp_vxsnan | nan(ps0B);
 	setSummaryFPSCR();
-	tmp2:4 = float2float(floatOne f/ ps1B);
+	tmp2:8 = float2float(floatOne f/ ps1B);
 	ps1D = float2float(tmp2);
 	cr1flags();
 }
 
 :ps_rsqrte fD,fB is OP=4 & fD & BITS_16_20=0 & fB & BITS_6_10=0 & XOP_1_5=26 & Rc=0 & ps0D & ps1D & ps0B & ps1B
 {
-	one:4 = 1;
-	floatOne:4 = int2float(one);
-	tmpSqrt1:4 = sqrt(ps0B);
+	one:8 = 1;
+	floatOne:8 = int2float(one);
+	tmpSqrt1:8 = sqrt(ps0B);
 	ps0D = (floatOne f/ tmpSqrt1);
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0B);
 	setSummaryFPSCR();
-	tmpSqrt2:4 = sqrt(ps1B);
+	tmpSqrt2:8 = sqrt(ps1B);
 	ps1D = (floatOne f/ tmpSqrt2);
 }
 
 :ps_rsqrte. fD,fB is OP=4 & fD & BITS_16_20=0 & fB & BITS_6_10=0 & XOP_1_5=26 & Rc=1 & ps0D & ps1D & ps0B & ps1B
 {
-	one:4 = 1;
-	floatOne:4 = int2float(one);
-	tmpSqrt1:4 = sqrt(ps0B);
+	one:8 = 1;
+	floatOne:8 = int2float(one);
+	tmpSqrt1:8 = sqrt(ps0B);
 	ps0D = (floatOne f/ tmpSqrt1);
 	setFPRF(ps0D);
 	fp_xx = fp_xx | fp_fi;
 	fp_vxsnan = fp_vxsnan | nan(ps0B);
 	setSummaryFPSCR();
-	tmpSqrt2:4 = sqrt(ps1B);
+	tmpSqrt2:8 = sqrt(ps1B);
 	ps1D = (floatOne f/ tmpSqrt2);
 	cr1flags();
 }
 
 :ps_sel fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=23 & Rc=0 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	zero:4 = 0;
-	zeroFloat:4 = int2float(zero);
+	zero:8 = 0;
+	zeroFloat:8 = int2float(zero);
 	ps0D = ps0C;
 	if (ps0A f>= zeroFloat) goto <ps1test>; 
 	ps0D = ps0B;
@@ -1751,8 +1755,8 @@ macro store_ps(ps0S, ps1S, EA, W, I) {
 
 :ps_sel. fD,fA,fC,fB is OP=4 & fD & fA & fB & fC & XOP_1_5=23 & Rc=1 & ps0D & ps1D & ps0B & ps1B & ps0A & ps1A & ps0C & ps1C
 {
-	zero:4 = 0;
-	zeroFloat:4 = int2float(zero);
+	zero:8 = 0;
+	zeroFloat:8 = int2float(zero);
 	ps0D = ps0C;
 	if (ps0A f>= zeroFloat) goto <ps1test>; 
 	ps0D = ps0B;

--- a/data/languages/ppc_gekko_broadway.slaspec
+++ b/data/languages/ppc_gekko_broadway.slaspec
@@ -795,11 +795,6 @@ define pcodeop TLBWrite;
 define pcodeop WriteExternalEnable;
 define pcodeop WriteExternalEnableImmediate;
 
-# Paired singles specific operations (they are too complex
-# to implement them as is)
-define pcodeop dequantize;
-define pcodeop quantize;
-
 ################################################################
 # Macros
 ################################################################
@@ -1158,209 +1153,152 @@ CRM_CR:	cr0		is CRM=128 & cr0	{tmp:4 = zext(cr0) << 28;export tmp;}
 # Paired singles quantized load and store instructions
 ################################################################
 
-define pcodeop __psq_l0;
-define pcodeop __psq_l1;
-:psq_l fD,dPlusRaOrZeroAddressPS,W,I is OP=56 & fD & A & W & I & dPlusRaOrZeroAddressPS & ps0D & ps1D
-{
-	EA:4 = dPlusRaOrZeroAddressPS;
-	wFlag:1 = W;
-	ps0D = __psq_l0(EA, I);
-	if (wFlag == 1) goto <wIsOne>;
-	ps1D = __psq_l1(EA, I);
-	goto inst_next;
-	<wIsOne>
+define pcodeop ldexpf;
+
+macro load_ps(ps0D, ps1D, EA, W, I) {
+	lt:1 = 0;
+	ls:1 = 0;
+	wFlag:1 = 0;
+	lt[0,3] = I[16,3];
+	ls[0,3] = I[24,6];
+	wFlag = W;
 	one:1 = 1;
 	floatOne:4 = int2float(one);
+
+	local scale;
+	if (ls == 0) goto <noscale>;
+	scale = ldexpf(-ls);
+	goto <continue_scale>;
+	<noscale>
+	scale = floatOne;
+
+	<continue_scale>
+
+	if (lt == 4 || lt == 6) goto <int8>;
+	if (lt == 5 || lt == 7) goto <int16>;
+	goto <float>;
+
+	<int8>
+	local x81 = *:1(EA);
+	local x82 = *:1(EA + 1);
+	ps0D = scale * int2float(x81);
+	if (wFlag) goto <int8w1>;
+	ps1D = scale * int2float(x82);
+	goto inst_next;
+	<int8w1>
 	ps1D = floatOne;
+	goto inst_next;
+
+	<int16>
+	local x61 = *:2(EA);
+	local x62 = *:2(EA + 2);
+	ps0D = scale * int2float(x61);
+	if (wFlag) goto <int16w1>;
+	ps1D = scale * int2float(x62);
+	goto inst_next;
+	<int16w1>
+	ps1D = floatOne;
+	goto inst_next;
+
+	<float>
+	ps0D = *:4(EA);
+	if (wFlag) goto <floatw1>;
+	ps1D = *:4(EA + 4);
+	goto inst_next;
+	<floatw1>
+	ps1D = floatOne;
+}
+
+:psq_l fD,dPlusRaOrZeroAddressPS,W,I is OP=56 & fD & W & I & dPlusRaOrZeroAddressPS & ps0D & ps1D
+{
+	EA:4 = dPlusRaOrZeroAddressPS;
+	load_ps(ps0D, ps1D, EA, W, I);
 }
 
 :psq_lu fD,dPlusRaAddressPS,W,I is OP=57 & fD & A & W & I & dPlusRaAddressPS & ps0D & ps1D
 {
 	EA:4 = dPlusRaAddressPS;
 	A = EA;
-	wFlag:1 = W;
-	type:1 = 0;
-	scale:1 = 0;
-	type[0,3] = I[16,3];
-	scale[0,3] = I[24,6];
-	if (type == 4 || type == 6) goto <int8>;
-	if (type == 5 || type == 7) goto <int16>;
-	goto <none>;
-	<int8>
-	ps0D = dequantize(EA, type, scale);
-	if (wFlag == 1) goto <wIsOne>;
-	ps1D = dequantize(EA + 1, type, scale);
-	goto inst_next;
-	<int16>
-	ps0D = dequantize(EA, type, scale);
-	if (wFlag == 1) goto <wIsOne>;
-	ps1D = dequantize(EA + 2, type, scale);
-	goto inst_next;
-	<none>
-	ps0D = *:4(EA);
-	ps1D = *:4(EA + 4);
-	if (wFlag == 0) goto inst_next;
-	<wIsOne>
-	one:1 = 1;
-	floatOne:4 = int2float(one);
-	ps1D = floatOne;
+	load_ps(ps0D, ps1D, EA, W, I);
 }
 
 :psq_lux fD,RA_OR_ZERO,B,WX,IX is OP=4 & fD & RA_OR_ZERO & A & B & WX & IX & XOP_1_6=38 & BIT_0=0 & ps0D & ps1D
 {
 	EA:4 = RA_OR_ZERO + B;
 	A = EA;
-	wFlag:1 = WX;
-	type:1 = 0;
-	scale:1 = 0;
-	type[0,3] = IX[16,3];
-	scale[0,3] = IX[24,6];
-	if (type == 4 || type == 6) goto <int8>;
-	if (type == 5 || type == 7) goto <int16>;
-	goto <none>;
-	<int8>
-	ps0D = dequantize(EA, type, scale);
-	if (wFlag == 1) goto <wIsOne>;
-	ps1D = dequantize(EA + 1, type, scale);
-	goto inst_next;
-	<int16>
-	ps0D = dequantize(EA, type, scale);
-	if (wFlag == 1) goto <wIsOne>;
-	ps1D = dequantize(EA + 2, type, scale);
-	goto inst_next;
-	<none>
-	ps0D = *:4(EA);
-	ps1D = *:4(EA + 4);
-	if (wFlag == 0) goto inst_next;
-	<wIsOne>
-	one:1 = 1;
-	floatOne:4 = int2float(one);
-	ps1D = floatOne;
+	load_ps(ps0D, ps1D, EA, WX, IX);
 }
 
 :psq_lx fD,RA_OR_ZERO,B,WX,IX is OP=4 & fD & RA_OR_ZERO & B & WX & IX & XOP_1_6=6 & BIT_0=0 & ps0D & ps1D
 {
 	EA:4 = RA_OR_ZERO + B;
-	wFlag:1 = WX;
-	type:1 = 0;
-	scale:1 = 0;
-	type[0,3] = IX[16,3];
-	scale[0,3] = IX[24,6];
-	if (type == 4 || type == 6) goto <int8>;
-	if (type == 5 || type == 7) goto <int16>;
-	goto <none>;
-	<int8>
-	ps0D = dequantize(EA, type, scale);
-	if (wFlag == 1) goto <wIsOne>;
-	ps1D = dequantize(EA + 1, type, scale);
-	goto inst_next;
-	<int16>
-	ps0D = dequantize(EA, type, scale);
-	if (wFlag == 1) goto <wIsOne>;
-	ps1D = dequantize(EA + 2, type, scale);
-	goto inst_next;
-	<none>
-	ps0D = *:4(EA);
-	ps1D = *:4(EA + 4);
-	if (wFlag == 0) goto inst_next;
-	<wIsOne>
-	one:1 = 1;
-	floatOne:4 = int2float(one);
-	ps1D = floatOne;
+	load_ps(ps0D, ps1D, EA, WX, IX);
 }
 
-define pcodeop __psq_st0;
-define pcodeop __psq_st1;
+macro store_ps(ps0S, ps1S, EA, W, I) {
+	lt:1 = 0;
+	ls:1 = 0;
+	lt[0,3] = I[0,3];
+	ls[0,3] = I[8,6];
+	wFlag:1 = W;
+
+	local scale;
+	if (ls == 0) goto <noscale>;
+	scale = ldexpf(ls);
+	goto <continue_scale>;
+	<noscale>
+	one:1 = 1;
+	floatOne:4 = int2float(one);
+	scale = floatOne;
+
+	<continue_scale>
+
+	if (lt == 4 || lt == 6) goto <int8>;
+	if (lt == 5 || lt == 7) goto <int16>;
+	goto <float>;
+
+	<int8>
+	*:1(EA) = trunc(scale f* ps0S);
+	if (wFlag == 1) goto inst_next;
+	*:1(EA + 1) = trunc(scale f* ps1S);
+	goto inst_next;
+
+	<int16>
+	*:2(EA) = trunc(scale f* ps0S);
+	if (wFlag == 1) goto inst_next;
+	*:2(EA + 2) = trunc(scale f* ps1S);
+	goto inst_next;
+
+	<float>
+	*:4(EA) = ps0S;
+	if (wFlag == 1) goto inst_next;
+	*:4(EA + 4) = ps1S;
+}
+
 :psq_st fS,dPlusRaOrZeroAddressPS,W,I is OP=60 & fS & A & W & I & dPlusRaOrZeroAddressPS & ps0S & ps1S
 {
 	EA:4 = dPlusRaOrZeroAddressPS;
-	wFlag:1 = W;
-	__psq_st0(EA, ps0S, I);
-	if (wFlag == 1) goto inst_next;
-	__psq_st1(EA, ps1S, I);
+	store_ps(ps0S, ps1S, EA, W, I);
 }
 
 :psq_stu fS,dPlusRaAddressPS,W,I is OP=61 & fS & A & W & I & dPlusRaAddressPS & ps0S & ps1S
 {
 	EA:4 = dPlusRaAddressPS;
 	A = EA;
-	wFlag:1 = W;
-	type:1 = 0;
-	scale:1 = 0;
-	type[0,3] = I[0,3];
-	scale[0,3] = I[8,6];
-	if (type == 4 || type == 6) goto <int8>;
-	if (type == 5 || type == 7) goto <int16>;
-	goto <none>;
-	<int8>
-	*:1(EA) = quantize(ps0S, type, scale);
-	if (wFlag == 1) goto inst_next;
-	*:1(EA + 1) = quantize(ps1S, type, scale);
-	goto inst_next;
-	<int16>
-	*:2(EA) = quantize(ps0S, type, scale);
-	if (wFlag == 1) goto inst_next;
-	*:2(EA + 2) = quantize(ps1S, type, scale);
-	goto inst_next;
-	<none>
-	*:4(EA) = ps0S;
-	if (wFlag == 1) goto inst_next;
-	*:4(EA + 4) = ps1S;
+	store_ps(ps0S, ps1S, EA, W, I);
 }
 
 :psq_stux fS,RA_OR_ZERO,B,WX,IX is OP=4 & fS & RA_OR_ZERO & A & B & WX & IX & XOP_1_6=39 & BIT_0=0 & ps0S & ps1S
 {
 	EA:4 = RA_OR_ZERO + B;
 	A = EA;
-	wFlag:1 = WX;
-	type:1 = 0;
-	scale:1 = 0;
-	type[0,3] = IX[0,3];
-	scale[0,3] = IX[8,6];
-	if (type == 4 || type == 6) goto <int8>;
-	if (type == 5 || type == 7) goto <int16>;
-	goto <none>;
-	<int8>
-	*:1(EA) = quantize(ps0S, type, scale);
-	if (wFlag == 1) goto inst_next;
-	*:1(EA + 1) = quantize(ps1S, type, scale);
-	goto inst_next;
-	<int16>
-	*:2(EA) = quantize(ps0S, type, scale);
-	if (wFlag == 1) goto inst_next;
-	*:2(EA + 2) = quantize(ps1S, type, scale);
-	goto inst_next;
-	<none>
-	*:4(EA) = ps0S;
-	if (wFlag == 1) goto inst_next;
-	*:4(EA + 4) = ps1S;
+	store_ps(ps0S, ps1S, EA, WX, IX);
 }
 
 :psq_stx fS,RA_OR_ZERO,B,WX,IX is OP=4 & fS & RA_OR_ZERO & B & WX & IX & XOP_1_6=7 & BIT_0=0 & ps0S & ps1S
 {
 	EA:4 = RA_OR_ZERO + B;
-	wFlag:1 = WX;
-	type:1 = 0;
-	scale:1 = 0;
-	type[0,3] = IX[0,3];
-	scale[0,3] = IX[8,6];
-	if (type == 4 || type == 6) goto <int8>;
-	if (type == 5 || type == 7) goto <int16>;
-	goto <none>;
-	<int8>
-	*:1(EA) = quantize(ps0S, type, scale);
-	if (wFlag == 1) goto inst_next;
-	*:1(EA + 1) = quantize(ps1S, type, scale);
-	goto inst_next;
-	<int16>
-	*:2(EA) = quantize(ps0S, type, scale);
-	if (wFlag == 1) goto inst_next;
-	*:2(EA + 2) = quantize(ps1S, type, scale);
-	goto inst_next;
-	<none>
-	*:4(EA) = ps0S;
-	if (wFlag == 1) goto inst_next;
-	*:4(EA + 4) = ps1S;
+	store_ps(ps0S, ps1S, EA, WX, IX);
 }
 
 ################################################################

--- a/data/languages/ppc_instructions_gekko_broadway.sinc
+++ b/data/languages/ppc_instructions_gekko_broadway.sinc
@@ -1186,20 +1186,21 @@
 }
 
 #fadds fr0,fr0,fr0	0xec 00 00 2a
-:fadds fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=21 & Rc=0
+:fadds fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=21 & Rc=0 & ps1T
 {
 	tmp:4 = float2float(fA f+ fB);
 	fD = float2float(tmp);
 	setFPAddFlags(fA,fB,fD);
-	
+	ps1T = fD;	
 }
 
 #fadds. fr0,fr0,fr0	0xec 00 00 2b
-:fadds. fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=21 & Rc=1
+:fadds. fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=21 & Rc=1 & ps1T
 {
 	tmp:4 = float2float(fA f+ fB);
 	fD = float2float(tmp);
 	setFPAddFlags(fA,fB,fD);
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -1359,18 +1360,20 @@
 }
 
 #fdivs fr0,fr0,fr0  0xec 00 00 24
-:fdivs fD,fA,fB   is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=18 & Rc=0
+:fdivs fD,fA,fB   is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=18 & Rc=0 & ps1T
 {
 	tmp:4 = float2float(fA f/ fB);
 	fD = float2float(tmp);
 	setFPDivFlags(fA,fB,fD);
+	ps1T = fD;	
 }
 #fdivs. fr0,fr0,fr0  0xec 00 00 25
-:fdivs. fD,fA,fB   is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=18 & Rc=1
+:fdivs. fD,fA,fB   is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=18 & Rc=1 & ps1T
 {
 	tmp:4 = float2float(fA f/ fB);
 	fD = float2float(tmp);
 	setFPDivFlags(fA,fB,fD);
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -1410,7 +1413,7 @@
 }
 
 #fmadds fr0,fr0,fr0,fr0	0xec 00 00 3a
-:fmadds fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=29 & Rc=0
+:fmadds fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=29 & Rc=0 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f+ fB);
@@ -1425,10 +1428,11 @@
 #	fp_vxisi = fp_vxisi | floatInfinityAdd(tmp, fB);
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
+	ps1T = fD;	
 }
 
 #fmadds. fr0,fr0,fr0,fr0	0xec 00 00 3b
-:fmadds. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=29 & Rc=1
+:fmadds. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=29 & Rc=1 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f+ fB);
@@ -1443,6 +1447,7 @@
 #	fp_vxisi = fp_vxisi | floatInfinityAdd(tmp, fB);
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -1494,7 +1499,7 @@
 }
 
 #fmsubs fr0,fr0,fr0,fr0	0xec 00 00 38
-:fmsubs fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=28 & Rc=0
+:fmsubs fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=28 & Rc=0 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f- fB);
@@ -1509,10 +1514,11 @@
 #	fp_vxisi = fp_vxisi | floatInfinitySub(tmp, fB);
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
+	ps1T = fD;	
 }
 
 #fmsubs. fr0,fr0,fr0,fr0	0xfc 00 00 39
-:fmsubs. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=28 & Rc=1
+:fmsubs. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=28 & Rc=1 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f- fB);
@@ -1527,6 +1533,7 @@
 #	fp_vxisi = fp_vxisi | floatInfinitySub(tmp, fB);
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -1545,19 +1552,21 @@
 }
 
 #fmuls fr0,fr0,fr0	0xec 00 00 32
-:fmuls fD,fA,fC	is $(NOTVLE) & OP=59 & fD & fA & fC & BITS_11_15=0 & XOP_1_5=25 & Rc=0
+:fmuls fD,fA,fC	is $(NOTVLE) & OP=59 & fD & fA & fC & BITS_11_15=0 & XOP_1_5=25 & Rc=0 & ps1T
 {
 	tmp:4 = float2float(fA f* fC);
 	fD = float2float(tmp);
 	setFPMulFlags(fA,fC,fD);
+	ps1T = fD;	
 }
 
 #fmuls. fr0,fr0,fr0	0xec 00 00 33
-:fmuls. fD,fA,fC	is $(NOTVLE) & OP=59 & fD & fA & fC & BITS_11_15=0 & XOP_1_5=25 & Rc=1
+:fmuls. fD,fA,fC	is $(NOTVLE) & OP=59 & fD & fA & fC & BITS_11_15=0 & XOP_1_5=25 & Rc=1 & ps1T
 {
 	tmp:4 = float2float(fA f* fC);
 	fD = float2float(tmp);
 	setFPMulFlags(fA,fC,fD);
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -1623,7 +1632,7 @@
 }
 
 #fnmadds fr0,fr0,fr0,fr0	0xec 00 00 3e
-:fnmadds fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=31 & Rc=0
+:fnmadds fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=31 & Rc=0 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f+ fB);
@@ -1638,10 +1647,11 @@
 #	fp_vxisi = fp_vxisi | floatInfinityAdd(tmp, fB);
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
+	ps1T = fD;	
 }
 
 #fnmadds. fr0,fr0,fr0,fr0	0xec 00 00 3f
-:fnmadds. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=31 & Rc=1
+:fnmadds. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=31 & Rc=1 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f+ fB);
@@ -1656,6 +1666,7 @@
 #	fp_vxisi = fp_vxisi | floatInfinityAdd(tmp, fB);
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -1696,7 +1707,7 @@
 }
 
 #fnmsubs fr0,fr0,fr0,fr0	0xec 00 00 3c
-:fnmsubs fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=30 & Rc=0
+:fnmsubs fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=30 & Rc=0 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f- fB);
@@ -1711,10 +1722,11 @@
 #	fp_vxisi = fp_vxisi | floatInfinitySub(tmp, fB);
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
+	ps1T = fD;	
 }
 
 #fnmsubs. fr0,fr0,fr0,fr0	0xfc 00 00 3d
-:fnmsubs. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=30 & Rc=1
+:fnmsubs. fD,fA,fC,fB	is $(NOTVLE) & OP=59 & fD & fA & fC & fB & XOP_1_5=30 & Rc=1 & ps1T
 {
 	tmp:8 = fA f* fC;
 	tmp2:4 = float2float(tmp f- fB);
@@ -1730,10 +1742,11 @@
 #	fp_vximz = fp_vximz | floatInfinityMulZero(fA,fC);
 	setSummaryFPSCR();
 	cr1flags();
+	ps1T = fD;	
 }
 
 #fres fr0,fr0		0xec 00 00 30
-:fres fD,fB	is $(NOTVLE) & OP=59 & fD & BITS_16_20 & fB & BITS_6_10=0 & XOP_1_5=24 & Rc=0 
+:fres fD,fB	is $(NOTVLE) & OP=59 & fD & BITS_16_20 & fB & BITS_6_10=0 & XOP_1_5=24 & Rc=0 & ps1T 
 {
 	one:8 = 1;
 	floatOne:8 = int2float(one);
@@ -1747,10 +1760,11 @@
 	fp_zx = fp_zx | (fB f== 0);
 	fp_vxsnan = fp_vxsnan | nan(fB);
 	setSummaryFPSCR();	
+	ps1T = fD;	
 }
 
 #fres. fr0,fr0		0xec 00 00 31
-:fres. fD,fB	is $(NOTVLE) & OP=59 & fD & BITS_16_20 & fB & BITS_6_10=0 & XOP_1_5=24 & Rc=1
+:fres. fD,fB	is $(NOTVLE) & OP=59 & fD & BITS_16_20 & fB & BITS_6_10=0 & XOP_1_5=24 & Rc=1 & ps1T
 {
 	one:8 = 1;
 	floatOne:8 = int2float(one);
@@ -1764,6 +1778,7 @@
 	fp_zx = fp_zx | (fB f== 0);
 	fp_vxsnan = fp_vxsnan | nan(fB);
 	setSummaryFPSCR();
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -1841,20 +1856,25 @@
 #fsel f0r,fr0,fr0,fr0	0xfc 00 00 2e
 :fsel fD,fA,fC,fB	is $(NOTVLE) & OP=63 & fD & fA & fB & fC & XOP_1_5=23 & Rc=0
 {
+	local tmpfA = fA;
+	local tmpfB = fB;
 	zero:4=0;
 	fD=fC;
-	if (fA f> int2float(zero)) goto inst_next; 
-	fD=fB; 
+	if (tmpfA f>= int2float(zero)) goto inst_next;
+	fD=tmpfB;
 }
 
 #fsel. fr0,fr0,fr0,fr0	0xfc 00 00 2f
 :fsel. fD,fA,fC,fB	is $(NOTVLE) & OP=63 & fD & fA & fB & fC & XOP_1_5=23 & Rc=1
 {
+	local tmpfA = fA;
+	local tmpfB = fB;
 	zero:4=0;
 	fD=fC;
+	if (tmpfA f>= int2float(zero)) goto <end>;
+	fD=tmpfB;
+	<end>
 	cr1flags();
-	if (fA f> int2float(zero)) goto inst_next; 
-	fD=fB; 
 }
 
 #fsqrt f0r,fr0	0xfc 00 00 2c
@@ -1929,20 +1949,21 @@
 }
 
 #fsubs fr0,fr0,fr0	0xec 00 00 28
-:fsubs fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=20 & Rc=0
+:fsubs fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=20 & Rc=0 & ps1T
 {
 	tmp:4 = float2float(fA f- fB);
 	fD = float2float(tmp);
 	setFPSubFlags(fA,fB,fD);
-	
+	ps1T = fD;	
 }
 
 #fsubs. fr0,fr0,fr0	0xec 00 00 29
-:fsubs. fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=20 & Rc=1
+:fsubs. fD,fA,fB	is $(NOTVLE) & OP=59 & fD & fA & fB & BITS_6_10=0 & XOP_1_5=20 & Rc=1 & ps1T
 {
 	tmp:4 = float2float(fA f- fB);
 	fD = float2float(tmp);
 	setFPSubFlags(fA,fB,fD);
+	ps1T = fD;	
 	cr1flags();
 }
 
@@ -2058,27 +2079,31 @@
 }
 
 #lfs fr0,8(r2)	0xc0 02 00 08	
-:lfs	fD,dPlusRaOrZeroAddress 	is $(NOTVLE) & OP=48 & fD & dPlusRaOrZeroAddress
+:lfs	fD,dPlusRaOrZeroAddress 	is $(NOTVLE) & OP=48 & fD & dPlusRaOrZeroAddress & ps1T
 {
 	fD = float2float(*:4(dPlusRaOrZeroAddress));
+	ps1T = fD;	
 }
 #lfsu fr0,8(r2)	0xc0 02 00 08	
-:lfsu	fD,dPlusRaAddress 	is $(NOTVLE) & OP=49 & fD & dPlusRaAddress & A
+:lfsu	fD,dPlusRaAddress 	is $(NOTVLE) & OP=49 & fD & dPlusRaAddress & A & ps1T
 {
 	A = dPlusRaAddress;
 	fD = float2float(*:4(A));
+	ps1T = fD;	
 }
 
 #lfsux fr0,r2,r0	0x7c 02 04 6e	
-:lfsux	fD,A,B 	is $(NOTVLE) & OP=31 & fD & A & B & XOP_1_10=567 & BIT_0=0
+:lfsux	fD,A,B 	is $(NOTVLE) & OP=31 & fD & A & B & XOP_1_10=567 & BIT_0=0 & ps1T
 {
 	A = A+B;
 	fD = float2float(*:4(A));
+	ps1T = fD;	
 }
 #lfsx fr0,r2,r0	0x7c 02 04 2e	
-:lfsx	fD,RA_OR_ZERO,B 	is $(NOTVLE) & OP=31 & fD & RA_OR_ZERO & B & XOP_1_10=535 & BIT_0=0
+:lfsx	fD,RA_OR_ZERO,B 	is $(NOTVLE) & OP=31 & fD & RA_OR_ZERO & B & XOP_1_10=535 & BIT_0=0 & ps1T
 {
 	fD = float2float(*:4(RA_OR_ZERO+B));
+	ps1T = fD;	
 }
 #lha	r0,4(0)		0xa8 00 00 04
 #lha	r0,4(r2)	0xa8 02 00 04


### PR DESCRIPTION
Provides full semantic information on pair singles load and store. If the GQRs are defined, this produces much clearer decompiler output.

Example before and after:
![copybefore](https://user-images.githubusercontent.com/107326447/233093534-45fa0012-f101-4b87-aab9-981a40aff026.png)
![copyafter](https://user-images.githubusercontent.com/107326447/233093566-d6ca4ed2-ef5a-49dd-8087-adc3d5dabe55.png)

