### PR TITLE
Mark GQRs as unaffected

### DIFF
--- a/data/languages/ppc_gekko_broadway.cspec
+++ b/data/languages/ppc_gekko_broadway.cspec
@@ -94,6 +94,14 @@
         <register name="r31"/>
         <register name="r1"/>
         <register name="cr4"/>
+        <register name="GQR0"/>
+        <register name="GQR1"/>
+        <register name="GQR2"/>
+        <register name="GQR3"/>
+        <register name="GQR4"/>
+        <register name="GQR5"/>
+        <register name="GQR6"/>
+        <register name="GQR7"/>
       </unaffected>
     </prototype>
   </default_proto>


### PR DESCRIPTION
Fixed ghidra thinking that GQRs were dirty after function calls, making it unable to simplify psq_l/psq_st expressions