### PR TITLE
Add unused but required vectorPermute pcodeop

### DIFF
--- a/data/languages/ppc_gekko_broadway.slaspec
+++ b/data/languages/ppc_gekko_broadway.slaspec
@@ -799,6 +799,10 @@ define pcodeop TLBWrite;
 define pcodeop WriteExternalEnable;
 define pcodeop WriteExternalEnableImmediate;
 
+# This is really used in the altivec version, but since it's a registered pcode op
+# and due to the way things get @included, this needs to be here
+define pcodeop vectorPermute;
+
 ################################################################
 # Macros
 ################################################################


### PR DESCRIPTION
This, including the comment, is copied from Ghidra's PPC definitions. Without the vectorPermute pcodeop defined, the
PPCEmulateInstructionStateModifier class produces an exception, breaking all Ghidra functionality that depends on pcode emulation.