### PR TITLE
Make project compatible with Gradle 8 and Ghidra 11.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Builds a Ghidra Extension for a given Ghidra installation.
 //
-// An absolute path to the Ghidra installation directory must be supplied either by setting the 
+// An absolute path to the Ghidra installation directory must be supplied either by setting the
 // GHIDRA_INSTALL_DIR environment variable or Gradle project property:
 //
-//     > export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra> 
+//     > export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra>
 //     > gradle
 //
 //         or
@@ -60,20 +60,20 @@ configurations {
 dependencies {
     implementation fileTree(dir: ghidraInstallDir + '/Ghidra/Processors', include: "**/*.jar")
     localDeps group: 'org.lz4', name: 'lz4-java', version: '1.5.1'
-    implementation configurations.localDeps
+    implementation 'org.lz4:lz4-java:1.5.1'
 }
 
 buildExtension {
-    baseName "${project.name}-${project.version}-${getGitHash()}-Ghidra_${ghidra_version}".replace(' ', '_')
-    extension 'zip'
-    destinationDir DISTRIBUTION_DIR
+    archiveBaseName = "${project.name}-${project.version}-${getGitHash()}-Ghidra_${ghidra_version}".replace(' ', '_')
+    archiveExtension = 'zip'
+    destinationDirectory = DISTRIBUTION_DIR
     version ''
-    
+
     // Make sure that we don't try to copy the same file with the same path into the
     // zip (this can happen!)
     duplicatesStrategy 'exclude'
-    
-    // This filtered property file copy must appear before the general 
+
+    // This filtered property file copy must appear before the general
     // copy to ensure that it is prefered over the unmodified file
     File propFile = new File(project.projectDir, "extension.properties")
     from (propFile) {
@@ -83,7 +83,7 @@ buildExtension {
         filter (org.apache.tools.ant.filters.ReplaceTokens, tokens: [extname: name])
         into PATH_IN_ZIP
     }
-    
+
     from (project.jar) {
         into PATH_IN_ZIP + "/lib"
     }
@@ -92,7 +92,7 @@ buildExtension {
     from (configurations.localDeps) {
         into PATH_IN_ZIP + "/lib"
     }
-        
+
     from (project.projectDir) {
         exclude 'build/**'
         exclude '*.gradle'
@@ -110,11 +110,7 @@ buildExtension {
         exclude 'developer_scripts'
         exclude '.antProperties.xml'
         exclude 'eclipse/**'
-        
-        into PATH_IN_ZIP
-    }
 
-    doLast {
-        println "\nCreated " + baseName + "." + extension + " in " + destinationDir
+        into PATH_IN_ZIP
     }
 }

--- a/src/main/java/gamecubeloader/analyzer/CodeWarriorDemanglerAnalyzer.java
+++ b/src/main/java/gamecubeloader/analyzer/CodeWarriorDemanglerAnalyzer.java
@@ -5,11 +5,12 @@ import ghidra.app.plugin.core.analysis.AbstractDemanglerAnalyzer;
 import ghidra.app.util.demangler.DemangledException;
 import ghidra.app.util.demangler.DemangledObject;
 import ghidra.app.util.demangler.DemanglerOptions;
+import ghidra.app.util.demangler.MangledContext;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.program.model.listing.Program;
 
 /***
- * 
+ *
  * Demangler analyzer for CodeWarrior symbols.
  */
 public class CodeWarriorDemanglerAnalyzer extends AbstractDemanglerAnalyzer {
@@ -20,7 +21,7 @@ public class CodeWarriorDemanglerAnalyzer extends AbstractDemanglerAnalyzer {
             "the name and apply datatypes to parameters.";
 
     private CodeWarriorDemangler demangler = new CodeWarriorDemangler();
-    
+
     public CodeWarriorDemanglerAnalyzer() {
         super(NAME, DESCRIPTION);
         setDefaultEnablement(true);
@@ -32,9 +33,9 @@ public class CodeWarriorDemanglerAnalyzer extends AbstractDemanglerAnalyzer {
     }
 
     @Override
-    protected DemangledObject doDemangle(String mangled, DemanglerOptions options, MessageLog log)
+    protected DemangledObject doDemangle(MangledContext context, MessageLog log)
             throws DemangledException {
-        DemangledObject demangled = demangler.demangle(mangled, options);
+        DemangledObject demangled = demangler.demangle(context);
         return demangled;
     }
 

--- a/src/main/java/gamecubeloader/common/CodeWarriorDemangler.java
+++ b/src/main/java/gamecubeloader/common/CodeWarriorDemangler.java
@@ -9,12 +9,12 @@ import ghidra.util.map.TypeMismatchException;
 public final class CodeWarriorDemangler implements Demangler {
     public final String CODEWARRIOR_DEMANGLE_PROP = "DemangleCW"; /* When defined, forces CodeWarrior demangling on all symbols. */
     public final String CODEWARRIOR_NO_DEMANGLE_PROP = "NoDemangleCW"; /* When defined, prevents CodeWarrior demangling on all symbols. */
-    
+
     public String str;
     public boolean containsInvalidSpecifier;
 
     public CodeWarriorDemangler() { } /* Empty constructor for DemanglerCmd::applyTo */
-    
+
     public CodeWarriorDemangler(String g) {
         this.str = g;
     }
@@ -74,7 +74,7 @@ public final class CodeWarriorDemangler implements Demangler {
                 break;
             }
         }
-        
+
         o.setTemplate(template);
     }
 
@@ -106,12 +106,12 @@ public final class CodeWarriorDemangler implements Demangler {
         // If the symbol starts with __, exit.
         if (firstDunder < 0)
             return null;
-        
+
         // Ensure that any trailing underscores in the function name are accounted for
         while (symbolName.charAt(firstDunder + 2) == '_') {
             firstDunder++;
         }
-        
+
         String parameters = symbolName.substring(firstDunder + 2);
         // After the dunder comes the class, if it exists, followed by 'F', followed by parameters.
         var demangler = new CodeWarriorDemangler(parameters);
@@ -129,7 +129,7 @@ public final class CodeWarriorDemangler implements Demangler {
 
             String functionName = symbolName.substring(0, firstDunder);
             String operatorName = demangleSpecialOperator(functionName);
-    
+
             if (operatorName != null) {
                 d.setOverloadedOperator(true);
                 d.setName(operatorName);
@@ -138,23 +138,23 @@ public final class CodeWarriorDemangler implements Demangler {
                     functionName = parentClass.getName();
                 else if (functionName.equals("__dt"))
                     functionName = "~" + parentClass.getName();
-    
+
                 d.setName(functionName);
-    
+
                 CodeWarriorDemangler.demangleTemplates(d);
             }
-            
+
             if (demangler.containsInvalidSpecifier)
                 return null;
-            
+
             return d;
         }
-        
+
         // It could be a member or vtable
         if (demangler.isEmpty()) {
             var name = symbolName.substring(0, firstDunder);
             var member = new DemangledVariable(symbolName, name, name);
-            
+
             if (parentClass != null) {
                 var namespace = parentClass.getNamespace();
                 var className = parentClass.getDemangledName();
@@ -165,10 +165,10 @@ public final class CodeWarriorDemangler implements Demangler {
                 classNamespace.setNamespace(namespace);
                 member.setNamespace(classNamespace);
             }
-            
+
             return member;
         }
-        
+
         return null;
     }
 
@@ -243,7 +243,7 @@ public final class CodeWarriorDemangler implements Demangler {
             var val = names.get(compCount - 1);
             var d = new DemangledDataType(null, val, val);
             demangleTemplates(d);
-            
+
             // Create namespaces
             DemangledType namespaceType = new DemangledType(null, names.get(0), names.get(0)); // Top level
             for (String ns : names.subList(1, names.size() - 1))
@@ -252,7 +252,7 @@ public final class CodeWarriorDemangler implements Demangler {
                 subNamespace.setNamespace(namespaceType);
                 namespaceType = subNamespace;
             }
-            
+
             d.setNamespace(namespaceType);
             return d;
         } else if (tok == 'F') {
@@ -264,13 +264,13 @@ public final class CodeWarriorDemangler implements Demangler {
                     break;
 
                 tok = hd();
-                
+
                 if (tok == '_') {
                     tk();
                     func.setReturnType(this.nextType());
                     break;
                 }
-                
+
                 func.addParameter(this.nextType());
             }
 
@@ -428,7 +428,7 @@ public final class CodeWarriorDemangler implements Demangler {
                     return "operator ->*";
             }
         }
-        
+
         return null;
     }
 
@@ -446,13 +446,12 @@ public final class CodeWarriorDemangler implements Demangler {
     }
 
     @Override
-    @SuppressWarnings("removal")
-    public DemangledObject demangle(String mangled, boolean demangleOnlyKnownPatterns) throws DemangledException {
-        return CodeWarriorDemangler.demangleSymbol(mangled);
+    public DemangledObject demangle(MangledContext mangledContext) throws DemangledException {
+        return CodeWarriorDemangler.demangleSymbol(mangledContext.getMangled());
     }
 
     @Override
-    public DemangledObject demangle(String mangled, DemanglerOptions options) throws DemangledException {
+    public DemangledObject demangle(String mangled) throws DemangledException {
         return CodeWarriorDemangler.demangleSymbol(mangled);
     }
 }


### PR DESCRIPTION
My editor also automatically removed trailing whitespace, sorry for the extra noise...

It would be great if this fix could also be applied to the rootcubed branch (the one where the PPC language definition is excluded). I can open another PR for that if you want.